### PR TITLE
Add Admin2 and named database support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The **Views** Plugin is for [Grav CMS](http://github.com/getgrav/grav) version 1
 
 Installing the Views plugin can be done in one of two ways. The GPM (Grav Package Manager) installation method enables you to quickly and easily install the plugin with a simple terminal command, while the manual method enables you to do so via a zip file.
 
-It has a requirement of the Grav **Database** plugin as it stores the views in a simple, file-based sqlite database file.  This will automatically be installed if you use GPM.
+It has a requirement of the Grav **Database** plugin. By default it stores views in a simple, file-based sqlite database file. This will automatically be installed if you use GPM.
 
 ### GPM Installation (Preferred)
 
@@ -20,9 +20,9 @@ The simplest way to install this plugin is via the [Grav Package Manager (GPM)](
 
 Other than standard Grav requirements, this plugin requires the **Database** plugin, which in turn has some system requirements:
 
-* **SQLite3** Database
 * **PHP pdo** Extension
-* **PHP pdo_sqlite** Driver
+* **PHP pdo_sqlite** Driver for the default SQLite database
+* The matching PDO driver for any configured Database plugin connection, for example **pdo_pgsql** for PostgreSQL
 
 | PHP by default comes with **PDO** and the vast majority of linux-based systems already come with SQLite.  
 
@@ -34,13 +34,34 @@ Here is the default configuration and an explanation of available options:
 
 ```yaml
 enabled: true
-autotrack: true    
+autotrack: true
+database:
+  driver: ''
+  connection: ''
+admin2:
+  reports: true
+  dashboard: true
+tracking:
+  humans_only: false
 ```
 
 The configuration options are as follows:
 
 * `enabled` - enable or disable the plugin instantly
 * `autotrack` - by default, views will track all pages using the `onPageInitialized` event, disable this to track manually
+* `database.driver` - leave blank to use the default SQLite database, or set to a Database plugin driver such as `pgsql`
+* `database.connection` - leave blank to use the default SQLite database, or set to a Database plugin named connection
+* `admin2.reports` - add the Grav Views report to Admin2 reports
+* `admin2.dashboard` - add a Grav Views top pages widget to the Admin2 dashboard
+* `tracking.humans_only` - when enabled, automatic tracking skips requests Grav identifies as bots or non-trackable browsers
+
+For PostgreSQL, configure a named connection in the Database plugin and point Views at that connection:
+
+```yaml
+database:
+  driver: pgsql
+  connection: page_views
+```
 
 ## Usage
 
@@ -78,7 +99,7 @@ Grav::instance()['views']->track($page->route(), 'widgets');
 
 ## Viewing
 
-Via the administrator plugin, you can view the current counts of the top 20 views by Visiting the **Reports** tab in the **Tools** section.  There will be an entry called `Grav Views`.  Alternatively you can query via the CLI or accessing the `Views` object directly and iterating over the values:
+Via the administrator plugin, you can view the current counts of the top 20 views by Visiting the **Reports** tab in the **Tools** section. There will be an entry called `Grav Views`. Grav 2 Admin2 also shows `Grav Views` in reports and can add a top pages widget to the dashboard. Alternatively you can query via the CLI or accessing the `Views` object directly and iterating over the values:
 
 ```php
 Grav::instance()['views']->getAll(null, 20, 'desc')
@@ -131,7 +152,6 @@ bin/plugin views set /bar 17 foos
 ```
 
 Will set the number of views with id '/bar' to the value `17` and defaults to type `foos`
-
 
 
 

--- a/admin-next/reports/views-report.js
+++ b/admin-next/reports/views-report.js
@@ -1,0 +1,115 @@
+const tag = window.__GRAV_REPORT_TAG;
+
+const escapeHtml = (value) => String(value ?? '')
+  .replace(/&/g, '&amp;')
+  .replace(/</g, '&lt;')
+  .replace(/>/g, '&gt;')
+  .replace(/"/g, '&quot;')
+  .replace(/'/g, '&#039;');
+
+class ViewsReportElement extends HTMLElement {
+  constructor() {
+    super();
+    this.attachShadow({ mode: 'open' });
+    this.data = null;
+  }
+
+  set report(value) {
+    this.data = value;
+    this.render();
+  }
+
+  get report() {
+    return this.data;
+  }
+
+  connectedCallback() {
+    this.render();
+  }
+
+  render() {
+    const items = Array.isArray(this.data?.items) ? this.data.items : [];
+    this.shadowRoot.innerHTML = `
+      <style>
+        :host {
+          display: block;
+          color: var(--foreground, inherit);
+          font: inherit;
+        }
+        table {
+          width: 100%;
+          border-collapse: collapse;
+          font-size: 0.875rem;
+        }
+        th,
+        td {
+          padding: 0.625rem 0.75rem;
+          border-bottom: 1px solid var(--border, rgba(148, 163, 184, 0.25));
+          text-align: left;
+          vertical-align: middle;
+        }
+        th {
+          color: var(--muted-foreground, #64748b);
+          font-size: 0.75rem;
+          font-weight: 600;
+          text-transform: uppercase;
+        }
+        td:last-child,
+        th:last-child {
+          text-align: right;
+        }
+        a {
+          color: var(--primary, #2563eb);
+          text-decoration: none;
+        }
+        a:hover {
+          text-decoration: underline;
+        }
+        .empty {
+          border: 1px dashed var(--border, rgba(148, 163, 184, 0.35));
+          border-radius: 0.5rem;
+          color: var(--muted-foreground, #64748b);
+          padding: 2rem;
+          text-align: center;
+        }
+        .count {
+          font-variant-numeric: tabular-nums;
+          font-weight: 600;
+        }
+        .type {
+          color: var(--muted-foreground, #64748b);
+        }
+      </style>
+      ${items.length === 0 ? `
+        <div class="empty">No views tracked yet.</div>
+      ` : `
+        <table>
+          <thead>
+            <tr>
+              <th>Page</th>
+              <th>Type</th>
+              <th>Views</th>
+            </tr>
+          </thead>
+          <tbody>
+            ${items.map((item) => {
+              const id = escapeHtml(item.id);
+              const href = String(item.id ?? '').startsWith('/') ? escapeHtml(item.id) : '';
+              return `
+                <tr>
+                  <td>${href ? `<a href="${href}" target="_blank" rel="noopener noreferrer">${id}</a>` : id}</td>
+                  <td class="type">${escapeHtml(item.type)}</td>
+                  <td class="count">${escapeHtml(item.count)}</td>
+                </tr>
+              `;
+            }).join('')}
+          </tbody>
+        </table>
+      `}
+    `;
+  }
+}
+
+if (tag && !customElements.get(tag)) {
+  customElements.define(tag, ViewsReportElement);
+}

--- a/admin-next/widgets/views.js
+++ b/admin-next/widgets/views.js
@@ -1,0 +1,152 @@
+const tag = window.__GRAV_WIDGET_TAG;
+
+const escapeHtml = (value) => String(value ?? '')
+  .replace(/&/g, '&amp;')
+  .replace(/</g, '&lt;')
+  .replace(/>/g, '&gt;')
+  .replace(/"/g, '&quot;')
+  .replace(/'/g, '&#039;');
+
+class ViewsWidgetElement extends HTMLElement {
+  constructor() {
+    super();
+    this.attachShadow({ mode: 'open' });
+    this.items = [];
+    this.error = '';
+    this.loading = true;
+  }
+
+  connectedCallback() {
+    this.render();
+    this.load();
+  }
+
+  async load() {
+    try {
+      const serverUrl = window.__GRAV_API_SERVER_URL || '';
+      const prefix = window.__GRAV_API_PREFIX || '/api/v1';
+      const token = window.__GRAV_API_TOKEN || '';
+      const response = await fetch(`${serverUrl}${prefix}/reports`, {
+        headers: token ? { 'X-API-Token': token } : {},
+      });
+
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}`);
+      }
+
+      const payload = await response.json();
+      const reports = Array.isArray(payload.data) ? payload.data : [];
+      const report = reports.find((item) => item.id === 'views');
+      this.items = Array.isArray(report?.items) ? report.items.slice(0, 6) : [];
+    } catch (error) {
+      this.error = error instanceof Error ? error.message : 'Unable to load views.';
+    } finally {
+      this.loading = false;
+      this.render();
+    }
+  }
+
+  render() {
+    const max = Math.max(...this.items.map((item) => Number(item.count) || 0), 1);
+    this.shadowRoot.innerHTML = `
+      <style>
+        :host {
+          display: block;
+          height: 100%;
+          color: var(--foreground, inherit);
+          font: inherit;
+        }
+        .wrap {
+          height: 100%;
+          border: 1px solid var(--border, rgba(148, 163, 184, 0.25));
+          border-radius: 0.5rem;
+          background: var(--card, transparent);
+          padding: 1rem;
+        }
+        h2 {
+          margin: 0 0 0.75rem;
+          font-size: 0.875rem;
+          font-weight: 600;
+        }
+        .empty,
+        .error {
+          color: var(--muted-foreground, #64748b);
+          font-size: 0.8125rem;
+          padding: 1rem 0;
+          text-align: center;
+        }
+        .error {
+          color: var(--destructive, #dc2626);
+        }
+        .items {
+          display: grid;
+          gap: 0.625rem;
+        }
+        .row {
+          display: grid;
+          gap: 0.25rem;
+        }
+        .line {
+          align-items: center;
+          display: flex;
+          gap: 0.75rem;
+          justify-content: space-between;
+          min-width: 0;
+        }
+        .route {
+          overflow: hidden;
+          text-overflow: ellipsis;
+          white-space: nowrap;
+        }
+        .count {
+          color: var(--muted-foreground, #64748b);
+          flex: 0 0 auto;
+          font-size: 0.75rem;
+          font-variant-numeric: tabular-nums;
+          font-weight: 600;
+        }
+        .bar {
+          height: 0.25rem;
+          overflow: hidden;
+          border-radius: 999px;
+          background: var(--secondary, rgba(148, 163, 184, 0.2));
+        }
+        .fill {
+          height: 100%;
+          border-radius: inherit;
+          background: var(--primary, #2563eb);
+        }
+      </style>
+      <div class="wrap">
+        <h2>Grav Views</h2>
+        ${this.loading ? `
+          <div class="empty">Loading views...</div>
+        ` : this.error ? `
+          <div class="error">${escapeHtml(this.error)}</div>
+        ` : this.items.length === 0 ? `
+          <div class="empty">No views tracked yet.</div>
+        ` : `
+          <div class="items">
+            ${this.items.map((item) => {
+              const count = Number(item.count) || 0;
+              const width = Math.max(4, Math.round((count / max) * 100));
+              return `
+                <div class="row">
+                  <div class="line">
+                    <span class="route">${escapeHtml(item.id)}</span>
+                    <span class="count">${escapeHtml(count)}</span>
+                  </div>
+                  <div class="bar"><div class="fill" style="width: ${width}%"></div></div>
+                </div>
+              `;
+            }).join('')}
+          </div>
+        `}
+      </div>
+    `;
+  }
+}
+
+if (tag && !customElements.get(tag)) {
+  customElements.define(tag, ViewsWidgetElement);
+}

--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -46,3 +46,60 @@ form:
         0: PLUGIN_ADMIN.DISABLED
       validate:
         type: bool
+
+    database:
+      type: section
+      title: Database Connection
+      underline: true
+      fields:
+        database.driver:
+          type: text
+          label: Database Driver
+          help: Leave blank to use the default SQLite database file. Set to a Database plugin driver such as pgsql to use a named connection.
+        database.connection:
+          type: text
+          label: Named Connection
+          help: Leave blank to use the default SQLite database file. Set to a Database plugin connection name when a driver is configured.
+
+    admin2:
+      type: section
+      title: Admin2
+      underline: true
+      fields:
+        admin2.reports:
+          type: toggle
+          label: Admin2 Reports
+          highlight: 1
+          default: 1
+          options:
+            1: PLUGIN_ADMIN.ENABLED
+            0: PLUGIN_ADMIN.DISABLED
+          validate:
+            type: bool
+        admin2.dashboard:
+          type: toggle
+          label: Admin2 Dashboard Widget
+          highlight: 1
+          default: 1
+          options:
+            1: PLUGIN_ADMIN.ENABLED
+            0: PLUGIN_ADMIN.DISABLED
+          validate:
+            type: bool
+
+    tracking:
+      type: section
+      title: Tracking
+      underline: true
+      fields:
+        tracking.humans_only:
+          type: toggle
+          label: Track Humans Only
+          help: Skip automatic tracking when Grav's browser detector identifies a bot or non-trackable request.
+          highlight: 0
+          default: 0
+          options:
+            1: PLUGIN_ADMIN.ENABLED
+            0: PLUGIN_ADMIN.DISABLED
+          validate:
+            type: bool

--- a/classes/Views.php
+++ b/classes/Views.php
@@ -23,25 +23,37 @@ class Views
     protected $path = 'user-data://views';
     protected $db_name = 'views.db';
     protected $table_total_views = 'total_views';
+    protected $supports_on_conflict;
 
     public function __construct($config)
     {
         $this->config = new Config($config);
+        $this->db = $this->connectDatabase();
+        $this->db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+
+        if (!$this->db->tableExists($this->table_total_views)) {
+            $this->createTables();
+        }
+    }
+
+    protected function connectDatabase()
+    {
+        $driver = trim((string) $this->config->get('database.driver', ''));
+        $connection = trim((string) $this->config->get('database.connection', ''));
+
+        if ($driver !== '' && $connection !== '') {
+            return Grav::instance()['database']->{$driver}($connection);
+        }
+
         $db_path = Grav::instance()['locator']->findResource($this->path, true, true);
 
-        // Create dir if it doesn't exist
         if (!file_exists($db_path)) {
             Folder::create($db_path);
         }
 
         $connect_string = 'sqlite:' . $db_path . '/' . $this->db_name;
 
-        $this->db = Grav::instance()['database']->connect($connect_string);
-        $this->db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-
-        if (!$this->db->tableExists($this->table_total_views)) {
-            $this->createTables();
-        }
+        return Grav::instance()['database']->connect($connect_string);
     }
 
     public function track($id, $type = 'pages', $amount = 1)
@@ -69,12 +81,14 @@ class Views
             return;
         }
 
-        $query = "INSERT INTO {$this->table_total_views} (id, count, type) VALUES (:id, :amount, :type) ON CONFLICT(id) DO UPDATE SET count = count + :amount";
+        $query = "INSERT INTO {$this->table_total_views} (id, count, type) VALUES (:id, :amount, :type) ON CONFLICT(id) DO UPDATE SET count = count + :update_amount, type = :update_type";
 
         $statement = $this->db->prepare($query);
         $statement->bindValue(':id', $id, PDO::PARAM_STR);
         $statement->bindValue(':amount', $amount, PDO::PARAM_INT);
+        $statement->bindValue(':update_amount', $amount, PDO::PARAM_INT);
         $statement->bindValue(':type', $type, PDO::PARAM_STR);
+        $statement->bindValue(':update_type', $type, PDO::PARAM_STR);
         $statement->execute();
     }
 
@@ -103,12 +117,14 @@ class Views
             return;
         }
 
-        $query = "INSERT INTO {$this->table_total_views} (id, count, type) VALUES (:id, :amount, :type) ON CONFLICT(id) DO UPDATE SET count = :amount";
+        $query = "INSERT INTO {$this->table_total_views} (id, count, type) VALUES (:id, :amount, :type) ON CONFLICT(id) DO UPDATE SET count = :update_amount, type = :update_type";
 
         $statement = $this->db->prepare($query);
         $statement->bindValue(':id', $id, PDO::PARAM_STR);
         $statement->bindValue(':amount', $amount, PDO::PARAM_INT);
+        $statement->bindValue(':update_amount', $amount, PDO::PARAM_INT);
         $statement->bindValue(':type', $type, PDO::PARAM_STR);
+        $statement->bindValue(':update_type', $type, PDO::PARAM_STR);
         $statement->execute();
     }
 
@@ -143,16 +159,21 @@ class Views
             $query .= 'WHERE type = :type ';
         }
 
-        $query .= "ORDER BY count {$order}, type LIMIT :limit OFFSET :offset";
+        $query .= "ORDER BY count {$order}, type";
 
+        if ($limit >= 0) {
+            $query .= " LIMIT :limit OFFSET :offset";
+        }
 
         $statement = $this->db->prepare($query);
 
         if (null !== $type) {
             $statement->bindValue(':type', $type, PDO::PARAM_STR);
         }
-        $statement->bindValue(':limit', $limit, PDO::PARAM_INT);
-        $statement->bindValue(':offset', $offset, PDO::PARAM_INT);
+        if ($limit >= 0) {
+            $statement->bindValue(':limit', $limit, PDO::PARAM_INT);
+            $statement->bindValue(':offset', $offset, PDO::PARAM_INT);
+        }
         $statement->execute();
 
         return $statement->fetchAll();
@@ -185,14 +206,21 @@ class Views
 
     protected function supportOnConflict()
     {
-        static $bool;
-
-        if ($bool === null) {
+        if ($this->supports_on_conflict === null) {
+            $driver = $this->db->getAttribute(PDO::ATTR_DRIVER_NAME);
+            if ($driver === 'pgsql') {
+                $this->supports_on_conflict = true;
+                return true;
+            }
+            if ($driver !== 'sqlite') {
+                $this->supports_on_conflict = false;
+                return false;
+            }
             $query = $this->db->query('SELECT sqlite_version()');
             $version = $query ? $query->fetch()[0] ?? 0 : 0;
-            $bool = version_compare($version, '3.24', '>=');
+            $this->supports_on_conflict = version_compare($version, '3.24', '>=');
         }
 
-        return $bool;
+        return $this->supports_on_conflict;
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -34,5 +34,8 @@
     "platform": {
       "php": "7.1.3"
     }
+  },
+  "scripts": {
+    "test": "php tests/run.php"
   }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,21 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "cefd6eba229d4d81d93d57a092398bcd",
+    "content-hash": "d93ee0a73bf8416bcc43cc0fa1cb9e95",
     "packages": [],
     "packages-dev": [],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
         "php": ">=7.1.3",
         "ext-pdo": "*"
     },
-    "platform-dev": [],
+    "platform-dev": {},
     "platform-overrides": {
         "php": "7.1.3"
-    }
+    },
+    "plugin-api-version": "2.9.0"
 }

--- a/tests/run.php
+++ b/tests/run.php
@@ -1,0 +1,412 @@
+<?php
+
+namespace Grav\Common\Config {
+    class Config
+    {
+        private $items;
+
+        public function __construct($items = [])
+        {
+            $this->items = is_array($items) ? $items : [];
+        }
+
+        public function get($key, $default = null)
+        {
+            $value = $this->items;
+            foreach (explode('.', $key) as $part) {
+                if (!is_array($value) || !array_key_exists($part, $value)) {
+                    return $default;
+                }
+                $value = $value[$part];
+            }
+
+            return $value;
+        }
+    }
+}
+
+namespace Grav\Common\Filesystem {
+    class Folder
+    {
+        public static function create($path)
+        {
+            if (!is_dir($path)) {
+                mkdir($path, 0777, true);
+            }
+        }
+    }
+}
+
+namespace Grav\Common {
+    class Grav
+    {
+        private static $instance;
+
+        public static function instance()
+        {
+            if (!self::$instance) {
+                self::$instance = new \ArrayObject([], \ArrayObject::ARRAY_AS_PROPS);
+            }
+
+            return self::$instance;
+        }
+    }
+
+    class Plugin
+    {
+        public $grav;
+        public $enabledEvents = [];
+        private $admin = false;
+
+        public function __construct()
+        {
+            $this->grav = Grav::instance();
+        }
+
+        public function setAdmin($admin)
+        {
+            $this->admin = $admin;
+        }
+
+        public function isAdmin()
+        {
+            return $this->admin;
+        }
+
+        public function enable(array $events)
+        {
+            $this->enabledEvents = array_merge($this->enabledEvents, $events);
+        }
+    }
+}
+
+namespace Grav\Plugin\Database {
+    class PDO extends \PDO
+    {
+    }
+}
+
+namespace RocketTheme\Toolbox\Event {
+    class Event extends \ArrayObject
+    {
+        public function __construct(array $items = [])
+        {
+            parent::__construct($items, \ArrayObject::ARRAY_AS_PROPS);
+        }
+    }
+}
+
+namespace Twig {
+    class TwigFunction
+    {
+        public function __construct($name, $callable = null, array $options = [])
+        {
+        }
+    }
+}
+
+namespace {
+    require_once __DIR__ . '/../classes/Views.php';
+    require_once __DIR__ . '/../views.php';
+
+    use Grav\Common\Config\Config;
+    use Grav\Common\Grav;
+    use Grav\Plugin\Views\Views;
+    use Grav\Plugin\ViewsPlugin;
+    use RocketTheme\Toolbox\Event\Event;
+
+    final class FakeLocator
+    {
+        private $path;
+
+        public function __construct($path)
+        {
+            $this->path = $path;
+        }
+
+        public function findResource($path, $absolute = false, $create = false)
+        {
+            return $this->path;
+        }
+    }
+
+    final class FakeDatabaseService
+    {
+        public $connectDsn;
+        public $namedConnection;
+        private $legacyPdo;
+        private $namedPdo;
+
+        public function __construct($legacyPdo, $namedPdo)
+        {
+            $this->legacyPdo = $legacyPdo;
+            $this->namedPdo = $namedPdo;
+        }
+
+        public function connect($dsn)
+        {
+            $this->connectDsn = $dsn;
+            return $this->legacyPdo;
+        }
+
+        public function __call($method, $arguments)
+        {
+            $this->namedConnection = [$method, $arguments[0] ?? null];
+            return $this->namedPdo;
+        }
+    }
+
+    final class FakePdo
+    {
+        public $prepared = [];
+        public $queries = [];
+        private $driver;
+        private $hasTable;
+
+        public function __construct($driver = 'sqlite', $hasTable = true)
+        {
+            $this->driver = $driver;
+            $this->hasTable = $hasTable;
+        }
+
+        public function setAttribute($attribute, $value)
+        {
+        }
+
+        public function getAttribute($attribute)
+        {
+            if ($attribute === \PDO::ATTR_DRIVER_NAME) {
+                return $this->driver;
+            }
+
+            return null;
+        }
+
+        public function tableExists($table)
+        {
+            return $this->hasTable;
+        }
+
+        public function exec($query)
+        {
+            $this->queries[] = ['exec', $query];
+        }
+
+        public function prepare($query)
+        {
+            $this->prepared[] = $query;
+            return new FakeStatement();
+        }
+
+        public function query($query)
+        {
+            $this->queries[] = ['query', $query];
+            if (strpos($query, 'sqlite_version()') !== false && $this->driver !== 'sqlite') {
+                throw new RuntimeException('PostgreSQL connections must not run SQLite version checks.');
+            }
+
+            return new FakeStatement(['3.44.0']);
+        }
+    }
+
+    final class FakeStatement
+    {
+        private $row;
+
+        public function __construct($row = [])
+        {
+            $this->row = $row;
+        }
+
+        public function bindValue($name, $value, $type = null)
+        {
+        }
+
+        public function execute()
+        {
+        }
+
+        public function fetch()
+        {
+            return $this->row;
+        }
+
+        public function fetchAll()
+        {
+            return [];
+        }
+
+        public function rowCount()
+        {
+            return 1;
+        }
+    }
+
+    final class FakeViewsReporter
+    {
+        public function getAll($type = null, $limit = -1, $order = 'ASC')
+        {
+            return [
+                ['id' => '/journal/example', 'count' => 7, 'type' => 'pages'],
+            ];
+        }
+    }
+
+    function assertSameValue($expected, $actual, $message)
+    {
+        if ($expected !== $actual) {
+            throw new RuntimeException(
+                $message . PHP_EOL .
+                'Expected: ' . var_export($expected, true) . PHP_EOL .
+                'Actual: ' . var_export($actual, true)
+            );
+        }
+    }
+
+    function assertTrueValue($condition, $message)
+    {
+        if (!$condition) {
+            throw new RuntimeException($message);
+        }
+    }
+
+    function setGrav(FakeDatabaseService $database)
+    {
+        $grav = Grav::instance();
+        $grav->exchangeArray([]);
+        $grav['database'] = $database;
+        $grav['locator'] = new FakeLocator(sys_get_temp_dir() . '/grav-views-tests');
+        $grav['config'] = new Config([
+            'plugins' => [
+                'views' => [
+                    'autotrack' => true,
+                    'admin2' => [
+                        'reports' => true,
+                        'dashboard' => true,
+                    ],
+                ],
+            ],
+        ]);
+
+        return $grav;
+    }
+
+    function testLegacySqliteConnectionRemainsDefault()
+    {
+        $legacyPdo = new FakePdo('sqlite');
+        $database = new FakeDatabaseService($legacyPdo, new FakePdo('pgsql'));
+        setGrav($database);
+
+        new Views([]);
+
+        assertTrueValue(strpos($database->connectDsn, 'sqlite:') === 0, 'Views should keep SQLite as the default connection.');
+        assertSameValue(null, $database->namedConnection, 'Views should not use a named connection without database config.');
+    }
+
+    function testNamedDatabaseConnectionCanBeUsed()
+    {
+        $database = new FakeDatabaseService(new FakePdo('sqlite'), new FakePdo('pgsql'));
+        setGrav($database);
+
+        new Views([
+            'database' => [
+                'driver' => 'pgsql',
+                'connection' => 'page_views',
+            ],
+        ]);
+
+        assertSameValue(['pgsql', 'page_views'], $database->namedConnection, 'Views should use configured Database plugin named connections.');
+        assertSameValue(null, $database->connectDsn, 'Views should not open the legacy SQLite file when a named connection is configured.');
+    }
+
+    function testPostgresTrackDoesNotRunSqliteVersionProbe()
+    {
+        $pdo = new FakePdo('pgsql');
+        $database = new FakeDatabaseService(new FakePdo('sqlite'), $pdo);
+        setGrav($database);
+
+        $views = new Views([
+            'database' => [
+                'driver' => 'pgsql',
+                'connection' => 'page_views',
+            ],
+        ]);
+        $views->track('/journal/example');
+
+        assertTrueValue(strpos($pdo->prepared[0], 'ON CONFLICT') !== false, 'PostgreSQL tracking should use an upsert query.');
+    }
+
+    function testUnlimitedGetAllOmitsLimitClause()
+    {
+        $pdo = new FakePdo('pgsql');
+        $database = new FakeDatabaseService(new FakePdo('sqlite'), $pdo);
+        setGrav($database);
+
+        $views = new Views([
+            'database' => [
+                'driver' => 'pgsql',
+                'connection' => 'page_views',
+            ],
+        ]);
+        $views->getAll(null, -1, 'desc');
+
+        assertTrueValue(strpos($pdo->prepared[0], 'LIMIT') === false, 'Unlimited getAll() should not bind a negative LIMIT.');
+    }
+
+    function testAdmin2ReportAndWidgetEventsAreRegistered()
+    {
+        assertTrueValue(method_exists(ViewsPlugin::class, 'onApiGenerateReports'), 'Views should expose an Admin2 report event handler.');
+        assertTrueValue(method_exists(ViewsPlugin::class, 'onApiDashboardWidgets'), 'Views should expose an Admin2 dashboard widget event handler.');
+
+        $grav = Grav::instance();
+        $grav->exchangeArray([]);
+        $grav['views'] = new FakeViewsReporter();
+
+        $plugin = new ViewsPlugin();
+        $reportEvent = new Event(['reports' => []]);
+        $plugin->onApiGenerateReports($reportEvent);
+        $reports = $reportEvent['reports'];
+
+        assertSameValue('views', $reports[0]['id'] ?? null, 'Views should add an Admin2 report id.');
+        assertSameValue('views', $reports[0]['provider'] ?? null, 'Views should use the plugin slug as the report provider.');
+        assertSameValue('views-report', $reports[0]['component'] ?? null, 'Views should point Admin2 at the report component.');
+
+        $widgetEvent = new Event(['widgets' => []]);
+        $plugin->onApiDashboardWidgets($widgetEvent);
+        $widgets = $widgetEvent['widgets'];
+
+        assertSameValue('views.top-pages', $widgets[0]['id'] ?? null, 'Views should add a top pages dashboard widget.');
+        assertSameValue('/gpm/plugins/views/widget-script', $widgets[0]['scriptUrl'] ?? null, 'Views widget should expose its Admin2 script URL.');
+    }
+
+    function testAdmin2ComponentFilesExist()
+    {
+        $report = __DIR__ . '/../admin-next/reports/views-report.js';
+        $widget = __DIR__ . '/../admin-next/widgets/views.js';
+
+        assertTrueValue(is_file($report), 'Views should ship an Admin2 report component.');
+        assertTrueValue(is_file($widget), 'Views should ship an Admin2 widget component.');
+        assertTrueValue(strpos(file_get_contents($report), 'window.__GRAV_REPORT_TAG') !== false, 'Report component should use the Admin2 report tag bridge.');
+        assertTrueValue(strpos(file_get_contents($widget), 'window.__GRAV_WIDGET_TAG') !== false, 'Widget component should use the Admin2 widget tag bridge.');
+    }
+
+    $tests = [
+        'testLegacySqliteConnectionRemainsDefault',
+        'testNamedDatabaseConnectionCanBeUsed',
+        'testPostgresTrackDoesNotRunSqliteVersionProbe',
+        'testUnlimitedGetAllOmitsLimitClause',
+        'testAdmin2ReportAndWidgetEventsAreRegistered',
+        'testAdmin2ComponentFilesExist',
+    ];
+
+    foreach ($tests as $test) {
+        try {
+            $test();
+        } catch (Throwable $error) {
+            fwrite(STDERR, $error->getMessage() . PHP_EOL);
+            exit(1);
+        }
+    }
+
+    fwrite(STDOUT, "All views plugin tests passed\n");
+}

--- a/views.php
+++ b/views.php
@@ -76,6 +76,21 @@ class ViewsPlugin extends Plugin
      */
     public function onPluginsInitialized()
     {
+        $events = [];
+        if ($this->grav['config']->get('plugins.views.admin2.reports', true)) {
+            $events['onApiGenerateReports'] = [
+                ['onApiGenerateReports', 10]
+            ];
+        }
+        if ($this->grav['config']->get('plugins.views.admin2.dashboard', true)) {
+            $events['onApiDashboardWidgets'] = [
+                ['onApiDashboardWidgets', 10]
+            ];
+        }
+        if ($events) {
+            $this->enable($events);
+        }
+
         if ($this->isAdmin()) {
             $this->enable([
                 'onAdminGenerateReports' => [
@@ -118,6 +133,43 @@ class ViewsPlugin extends Plugin
         $reports['Grav Views'] = $this->grav['twig']->processTemplate('reports/views-report.html.twig', $data);
     }
 
+    public function onApiGenerateReports(Event $e)
+    {
+        $items = $this->grav['views']->getAll(null, 20, 'desc');
+        $total = 0;
+        foreach ($items as $item) {
+            $total += (int) ($item['count'] ?? 0);
+        }
+
+        $reports = $e['reports'];
+        $reports[] = [
+            'id' => 'views',
+            'title' => 'Grav Views',
+            'provider' => 'views',
+            'component' => 'views-report',
+            'status' => 'success',
+            'message' => $items ? $total . ' tracked views across top pages.' : 'No views tracked yet.',
+            'items' => $items,
+        ];
+        $e['reports'] = $reports;
+    }
+
+    public function onApiDashboardWidgets(Event $e)
+    {
+        $widgets = $e['widgets'];
+        $widgets[] = [
+            'id' => 'views.top-pages',
+            'label' => 'Grav Views',
+            'icon' => 'Eye',
+            'sizes' => ['sm', 'md'],
+            'defaultSize' => 'sm',
+            'authorize' => 'api.reports.read',
+            'priority' => 55,
+            'scriptUrl' => '/gpm/plugins/views/widget-script',
+        ];
+        $e['widgets'] = $widgets;
+    }
+
     /**
      * Add current directory to twig lookup paths.
      */
@@ -136,6 +188,16 @@ class ViewsPlugin extends Plugin
 
     public function onPageInitialized(Event $event)
     {
+        if ($this->grav['config']->get('plugins.views.tracking.humans_only', false)) {
+            $browser = $this->grav['browser'] ?? null;
+            if ($browser && method_exists($browser, 'isHuman') && !$browser->isHuman()) {
+                return;
+            }
+            if ($browser && method_exists($browser, 'isTrackable') && !$browser->isTrackable()) {
+                return;
+            }
+        }
+
         $page = $event['page'];
 
         $this->grav['views']->track($page->route(), 'pages');

--- a/views.yaml
+++ b/views.yaml
@@ -1,2 +1,10 @@
 enabled: true
 autotrack: true
+database:
+  driver: ''
+  connection: ''
+admin2:
+  reports: true
+  dashboard: true
+tracking:
+  humans_only: false


### PR DESCRIPTION
## Summary
- Preserve the default SQLite views database while allowing Views to use Database plugin named connections such as PostgreSQL.
- Add Admin2 report and dashboard widget integration through the API plugin events and `admin-next` web component conventions.
- Make tracking and listing queries work across SQLite and PostgreSQL, including no negative `LIMIT` binding for unlimited results.
- Add focused coverage for legacy SQLite, named PostgreSQL-style connections, Admin2 event payloads, and component files.

## Database prerequisite
- PostgreSQL named connections need getgrav/grav-plugin-database#12 so the Database plugin preserves the `;sslmode=` DSN key.

## Test Plan
- `composer test`
- `php -l classes/Views.php`
- `php -l views.php`
- `php -l tests/run.php`
- `node --check admin-next/reports/views-report.js`
- `node --check admin-next/widgets/views.js`

Note: `composer validate --strict` still reports the existing `support.irc` metadata warning.