### PR TITLE
Fix PostgreSQL views upsert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v1.3.1
+## 06/12/2026
+
+1. [](#bugfix)
+    * Fixed PostgreSQL tracking upserts by qualifying the existing `count` column in `ON CONFLICT` updates
+
 # v1.3.0
 ## 06/11/2026
 

--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -1,7 +1,7 @@
 name: Views
 type: plugin
 slug: views
-version: 1.3.0
+version: 1.3.1
 description: Simple View tracking and reporting
 icon: eye
 author:

--- a/classes/Views.php
+++ b/classes/Views.php
@@ -81,7 +81,7 @@ class Views
             return;
         }
 
-        $query = "INSERT INTO {$this->table_total_views} (id, count, type) VALUES (:id, :amount, :type) ON CONFLICT(id) DO UPDATE SET count = count + :update_amount, type = :update_type";
+        $query = "INSERT INTO {$this->table_total_views} (id, count, type) VALUES (:id, :amount, :type) ON CONFLICT(id) DO UPDATE SET count = {$this->table_total_views}.count + :update_amount, type = :update_type";
 
         $statement = $this->db->prepare($query);
         $statement->bindValue(':id', $id, PDO::PARAM_STR);

--- a/tests/run.php
+++ b/tests/run.php
@@ -347,6 +347,23 @@ namespace {
         assertTrueValue(strpos($pdo->prepared[0], 'ON CONFLICT') !== false, 'PostgreSQL tracking should use an upsert query.');
     }
 
+    function testPostgresTrackQualifiesCountInUpsert()
+    {
+        $pdo = new FakePdo('pgsql');
+        $database = new FakeDatabaseService(new FakePdo('sqlite'), $pdo);
+        setGrav($database);
+
+        $views = new Views([
+            'database' => [
+                'driver' => 'pgsql',
+                'connection' => 'page_views',
+            ],
+        ]);
+        $views->track('/journal/example');
+
+        assertTrueValue(strpos($pdo->prepared[0], 'total_views.count + :update_amount') !== false, 'PostgreSQL tracking should qualify the existing count column in upserts.');
+    }
+
     function testUnlimitedGetAllOmitsLimitClause()
     {
         $pdo = new FakePdo('pgsql');
@@ -425,6 +442,7 @@ namespace {
         'testLegacySqliteConnectionRemainsDefault',
         'testNamedDatabaseConnectionCanBeUsed',
         'testPostgresTrackDoesNotRunSqliteVersionProbe',
+        'testPostgresTrackQualifiesCountInUpsert',
         'testUnlimitedGetAllOmitsLimitClause',
         'testAdmin2ReportAndWidgetEventsAreRegistered',
         'testAdmin2ComponentFilesExist',


### PR DESCRIPTION
## Summary

- qualify the existing `total_views.count` column in PostgreSQL `ON CONFLICT` tracking updates
- add a regression test for the PostgreSQL upsert SQL
- bump the plugin blueprint version to `1.3.1` and add the changelog entry

## Why

PostgreSQL treats the unqualified `count` reference in `ON CONFLICT DO UPDATE SET count = count + :update_amount` as ambiguous. During automatic page tracking this raises `SQLSTATE[42702]`, so the update needs to qualify the existing table column explicitly.

<img width="747" height="493" alt="image" src="https://github.com/user-attachments/assets/f22e80ba-f60a-4a23-ab3f-d91b18f7be26" />
