### PR TITLE
Skip autotracking pages without routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v1.3.2
+## 06/18/2026
+
+1. [](#bugfix)
+    * Skipped automatic page-view tracking when generated or plugin pages do not expose a real route
+
 # v1.3.1
 ## 06/12/2026
 

--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -1,7 +1,7 @@
 name: Views
 type: plugin
 slug: views
-version: 1.3.1
+version: 1.3.2
 description: Simple View tracking and reporting
 icon: eye
 author:

--- a/tests/run.php
+++ b/tests/run.php
@@ -252,6 +252,31 @@ namespace {
         }
     }
 
+    final class FakeViewsTracker
+    {
+        public $tracked = [];
+
+        public function track($id, $type = 'pages')
+        {
+            $this->tracked[] = [$id, $type];
+        }
+    }
+
+    final class FakePageRoute
+    {
+        private $route;
+
+        public function __construct($route)
+        {
+            $this->route = $route;
+        }
+
+        public function route()
+        {
+            return $this->route;
+        }
+    }
+
     final class FakeRouteCollector
     {
         public $routes = [];
@@ -438,6 +463,29 @@ namespace {
         assertTrueValue(strpos($widget, '/reports') === false, 'Widget should not hit the heavyweight /reports endpoint.');
     }
 
+    function testAutotrackSkipsPagesWithoutRoutes()
+    {
+        $grav = Grav::instance();
+        $grav->exchangeArray([]);
+        $grav['config'] = new Config([
+            'plugins' => [
+                'views' => [
+                    'tracking' => [
+                        'humans_only' => false,
+                    ],
+                ],
+            ],
+        ]);
+        $grav['views'] = new FakeViewsTracker();
+
+        $plugin = new ViewsPlugin();
+        $plugin->onPageInitialized(new Event(['page' => new FakePageRoute(null)]));
+        $plugin->onPageInitialized(new Event(['page' => new FakePageRoute('')]));
+        $plugin->onPageInitialized(new Event(['page' => new FakePageRoute('/journal/example')]));
+
+        assertSameValue([['/journal/example', 'pages']], $grav['views']->tracked, 'Autotrack should ignore plugin/dummy pages that do not have a real route.');
+    }
+
     $tests = [
         'testLegacySqliteConnectionRemainsDefault',
         'testNamedDatabaseConnectionCanBeUsed',
@@ -448,6 +496,7 @@ namespace {
         'testAdmin2ComponentFilesExist',
         'testDashboardWidgetEndpointIsRegistered',
         'testWidgetUsesLightweightEndpointNotReports',
+        'testAutotrackSkipsPagesWithoutRoutes',
     ];
 
     foreach ($tests as $test) {

--- a/views.php
+++ b/views.php
@@ -213,8 +213,13 @@ class ViewsPlugin extends Plugin
         }
 
         $page = $event['page'];
+        $route = is_object($page) && method_exists($page, 'route') ? (string) $page->route() : '';
 
-        $this->grav['views']->track($page->route(), 'pages');
+        if ($route === '') {
+            return;
+        }
+
+        $this->grav['views']->track($route, 'pages');
     }
 
     /**


### PR DESCRIPTION
## Summary
- skip automatic page-view tracking when the initialized page has no real route
- add a regression covering null, empty, and normal page routes
- bump plugin metadata and changelog to 1.3.2

## Why
Generated/plugin pages such as sitemap pages (`sitemap.xml`) can initialize without a route. Tracking those as page views can insert an empty/null id into Views storage, which is especially visible with PostgreSQL-backed storage constraints.

Potentially also fixes #1.