### PR TITLE
Skip tracking empty view IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v1.3.3
+## 06/19/2026
+
+1. [](#bugfix)
+    * Skipped tracking when manual or Twig calls pass an empty view ID
+
 # v1.3.2
 ## 06/18/2026
 

--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -1,7 +1,7 @@
 name: Views
 type: plugin
 slug: views
-version: 1.3.2
+version: 1.3.3
 description: Simple View tracking and reporting
 icon: eye
 author:

--- a/classes/Views.php
+++ b/classes/Views.php
@@ -58,6 +58,12 @@ class Views
 
     public function track($id, $type = 'pages', $amount = 1)
     {
+        $id = (string) $id;
+
+        if ($id === '') {
+            return;
+        }
+
         // Support SQLite < 3.24
         if (!$this->supportOnConflict()) {
             $query = "UPDATE {$this->table_total_views} SET count = count + :amount, type = :type WHERE id = :id";

--- a/tests/run.php
+++ b/tests/run.php
@@ -372,6 +372,25 @@ namespace {
         assertTrueValue(strpos($pdo->prepared[0], 'ON CONFLICT') !== false, 'PostgreSQL tracking should use an upsert query.');
     }
 
+    function testTrackSkipsEmptyIds()
+    {
+        $pdo = new FakePdo('pgsql');
+        $database = new FakeDatabaseService(new FakePdo('sqlite'), $pdo);
+        setGrav($database);
+
+        $views = new Views([
+            'database' => [
+                'driver' => 'pgsql',
+                'connection' => 'page_views',
+            ],
+        ]);
+        $views->track(null);
+        $views->track('');
+        $views->track('/journal/example');
+
+        assertSameValue(1, count($pdo->prepared), 'Views should only prepare a tracking query when the id is non-empty.');
+    }
+
     function testPostgresTrackQualifiesCountInUpsert()
     {
         $pdo = new FakePdo('pgsql');
@@ -490,6 +509,7 @@ namespace {
         'testLegacySqliteConnectionRemainsDefault',
         'testNamedDatabaseConnectionCanBeUsed',
         'testPostgresTrackDoesNotRunSqliteVersionProbe',
+        'testTrackSkipsEmptyIds',
         'testPostgresTrackQualifiesCountInUpsert',
         'testUnlimitedGetAllOmitsLimitClause',
         'testAdmin2ReportAndWidgetEventsAreRegistered',


### PR DESCRIPTION
## Summary
- Ignore null or empty IDs inside `Views::track()` before preparing tracking queries
- Add a regression test proving empty IDs do not reach PDO while normal page IDs still track
- Add `v1.3.3` release notes and bump the plugin blueprint version to `1.3.3`
